### PR TITLE
Bump to JDK11 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/.sbt/boot/
 
 jdk:
-  - openjdk8
+  - openjdk11
 
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.


### PR DESCRIPTION
Update on JDK version for builds since 11 is the new LTS for OpenJDK.