### PR TITLE
Remove reference to sbt-dotty plugin

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -5,6 +5,3 @@
 This is a normal sbt project, you can compile code with `sbt compile` and run it
 with `sbt run`, `sbt console` will start a Dotty REPL. For more information on
 cross-compilation in sbt, see <https://www.scala-sbt.org/1.x/docs/Cross-Build.html>.
-
-For more information on the sbt-dotty plugin, see the
-[scala3-example-project](https://github.com/scala/scala3-example-project/blob/main/README.md).


### PR DESCRIPTION
sbt-dotty was removed in https://github.com/scala/scala3-cross.g8/commit/3af4f41d62181953d46ee0f61d4bdc00ac75be98.